### PR TITLE
remove decodeURIComponent to stop choking on % character

### DIFF
--- a/background.js
+++ b/background.js
@@ -47,7 +47,7 @@ chrome.extension.onConnect.addListener((port) => {
 chrome.webRequest.onBeforeRequest.addListener(
 	(details) => {
 		if (details.url.startsWith('https://api.segment.io/v1')) {
-			var postedString = decodeURIComponent(String.fromCharCode.apply(null,new Uint8Array(details.requestBody.raw[0].bytes)));
+			var postedString = String.fromCharCode.apply(null,new Uint8Array(details.requestBody.raw[0].bytes));
 			
 			var rawEvent = JSON.parse(postedString);
 			


### PR DESCRIPTION
We ran into a peculiar issue where the extension wasn't picking up a certain event, turns out it was because decodeURIComponent was choking on a % character in the payload.

Everything seems to work fine without it, but I may have missed something.