### PR TITLE
Api custom domains

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,15 @@
 {
   "name": "Segment Event Tracker",
   "manifest_version": 2,
-  "version": "1.5",
+  "version": "1.6",
   "description": "See when Segment events are being tracked.",
   "permissions": [
   	"<all_urls>",
     "http://*/*",
     "https://*/*",
   	"webRequest",
-  	"webRequestBlocking"
+    "webRequestBlocking",
+    "storage"
   ],
   "browser_action": {
     "default_icon": "logo.png",

--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,18 @@ body {
 	max-height: 460px;
 	overflow: auto;
 }
+#configureButton {
+	position: absolute;
+	right: 20px;
+	top: 20px;
+}
+.configurationDiv {
+	width: 100%;
+}
+#apiDomain {
+	width: 100%;
+	margin-top: 10px;
+}
 .eventTracked {
 	padding: 10px;
 	margin-bottom: 1px;
@@ -47,7 +59,7 @@ h1 {
     font-size: 26px;
     font-weight: normal;
 }
-.clearButtonDiv {
+.buttonDiv {
 	padding-top: 10px;
 	text-align: right;
 }
@@ -75,12 +87,18 @@ input[type=button] {
 	<img class="logo" src="logo32.png">
 
 	<h1>Events tracked to Segment</h1>
-
-	<div id="trackMessages">
-		Events will be here
+	<input type="button" id="configureButton" value="Configure">
+	<div id="contentDiv">
+		<div id="trackMessages">
+			Events will be here
+		</div>
+		<div class="buttonDiv">
+			<input type="button" id="clearButton" value="Clear log from this tab">
+		</div>
 	</div>
-	<div class="clearButtonDiv">
-		<input type="button" id="clearButton" value="Clear log from this tab">
+	<div id="configurationDiv" class="configurationDiv" hidden="hidden">
+		API domains - comma separated list of domains used for Segment events publishing 
+		<textarea id="apiDomain" value="api.segment.io" placeholder="api.segment.io" rows="3">
 	</div>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,5 @@
+var apiDomainDefault = 'api.segment.io';
+
 function showEvent(number) {
 	document.getElementById('eventContent_' + number).style.display = 'block';
 }
@@ -100,7 +102,34 @@ port.onMessage.addListener((msg) => {
 	}
 });
 
+function toggleConfiguration() {
+	var configurationDiv = document.getElementById('configurationDiv');
+	configurationDiv.hidden = !configurationDiv.hidden; 
+
+	var contentDiv = document.getElementById('contentDiv');
+	contentDiv.hidden = !contentDiv.hidden; 
+}
+
+function updateApiDomain(apiDomain) {
+	chrome.storage.local.set({segment_api_domain: apiDomain || apiDomainDefault}, function() {
+	});
+}
+
+function handleApiDomainUpdates() {
+	var apiDomainInput = document.getElementById('apiDomain');
+	
+	chrome.storage.local.get(['segment_api_domain'], function(result) {
+		apiDomainInput.value = result.segment_api_domain || apiDomainDefault;
+		apiDomainInput.onchange = () => updateApiDomain(apiDomainInput.value);
+	});
+}
+
 document.addEventListener('DOMContentLoaded', function() {
 	var clearButton = document.getElementById('clearButton');
 	clearButton.onclick = clearTabLog;
+
+	var configureButton = document.getElementById('configureButton');
+	configureButton.onclick = toggleConfiguration;
+
+	handleApiDomainUpdates();
 });


### PR DESCRIPTION
Hi Martin,

Segment recently introduced feature to collect data through [custom domains](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/custom-proxy/) instead of 'api.segment.io'. This feature should enable users of such domains to observe events which are collected from their websites. We added simple configuration where user can provide comma separated list of domains which will be monitored. Default value is still set to original 'api.segment.io' and it will not affect current users of extension in any way.

![image](https://user-images.githubusercontent.com/56534411/102619388-a78fe280-413c-11eb-9b40-d926234599aa.png)

Regards,
Josef
