### PR TITLE
Allow filtering events by name

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -9,6 +9,12 @@ body {
 	max-height: 460px;
 	overflow: auto;
 }
+#filterInput {
+	position: absolute;
+	right: 110px;
+	top: 25px;
+	height: 25px;
+}
 #configureButton {
 	position: absolute;
 	right: 20px;
@@ -24,6 +30,9 @@ body {
 .eventTracked {
 	padding: 10px;
 	margin-bottom: 1px;
+}
+.eventTracked.hidden {
+	display: none;
 }
 .eventInfo {
 	font-size: 16px;
@@ -76,7 +85,7 @@ input[type=button] {
 }
 .eventType_pageLoad {
 	background-color: #9da6b0;
-}	
+}
 .eventType_track {
 	background-color: #dddddd;
 }
@@ -87,6 +96,7 @@ input[type=button] {
 	<img class="logo" src="logo32.png">
 
 	<h1>Events tracked to Segment</h1>
+	<input type="text" id="filterInput" placeholder="Filter">
 	<input type="button" id="configureButton" value="Configure">
 	<div id="contentDiv">
 		<div id="trackMessages">
@@ -97,7 +107,7 @@ input[type=button] {
 		</div>
 	</div>
 	<div id="configurationDiv" class="configurationDiv" hidden="hidden">
-		API domains - comma separated list of domains used for Segment events publishing 
+		API domains - comma separated list of domains used for Segment events publishing
 		<textarea id="apiDomain" value="api.segment.io" placeholder="api.segment.io" rows="3">
 	</div>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -11,7 +11,7 @@ function printVariable(jsonObject,level) {
 			returnString += '<span class="key">';
 			returnString += key;
 			returnString += '</span>';
-			
+
 			if (typeof jsonObject[key] == 'object') {
 				returnString += ' {' + printVariable(jsonObject[key],level + 1) + '}';
 			}
@@ -20,7 +20,7 @@ function printVariable(jsonObject,level) {
 				if (isNaN(jsonObject[key])) {
 					type = 'string';
 				}
-				
+
 				returnString += ': ';
 				returnString += '<span class="' + type + '">';
 				returnString += jsonObject[key];
@@ -34,7 +34,7 @@ function printVariable(jsonObject,level) {
 function queryForUpdate() {
 	chrome.tabs.query({ active: true, currentWindow: true },(tabs) => {
 		var currentTab = tabs[0];
-		
+
 		port.postMessage({
 			type: "update",
 			tabId: currentTab.id
@@ -45,7 +45,7 @@ function queryForUpdate() {
 function clearTabLog() {
 	chrome.tabs.query({ active: true, currentWindow: true },(tabs) => {
 		var currentTab = tabs[0];
-		
+
 		port.postMessage({
 			type: "clear",
 			tabId: currentTab.id
@@ -62,23 +62,23 @@ queryForUpdate();
 port.onMessage.addListener((msg) => {
 	if (msg.type == "update") {
 		// console.log(jsonObject);
-		
+
 		var prettyEventsString = '';
-		
+
 		if (msg.events.length > 0) {
 			for (var i=0;i<msg.events.length;i++) {
 				var event = msg.events[i];
-				
+
 				var jsonObject = JSON.parse(event.raw)
 				var eventString = '';
-				
+
 				eventString += '<div class="eventTracked eventType_' + event.type + '">';
 					eventString += '<div class="eventInfo" number="' + i + '"><span class="eventName">' + event.eventName + '</span> - ' + event.trackedTime + '<br />' + event.hostName + '</div>';
 					eventString += '<div class="eventContent" id="eventContent_' + i + '">';
 						eventString += printVariable(jsonObject,0);
 					eventString += '</div>';
 				eventString += '</div>';
-				
+
 				prettyEventsString += eventString;
 			}
 		}
@@ -102,12 +102,25 @@ port.onMessage.addListener((msg) => {
 	}
 });
 
+function filterEvents(keyPressedEvent) {
+	var filter = new RegExp(keyPressedEvent.target.value, 'gi');
+	var eventElements = document.getElementById('trackMessages').getElementsByClassName('eventTracked');
+	for(eventElement of eventElements) {
+		var eventName = eventElement.getElementsByClassName('eventName')[0].textContent;
+		if (eventName.match(filter)) {
+			eventElement.classList.remove('hidden');
+		} else {
+			eventElement.classList.add('hidden');
+		}
+	}
+}
+
 function toggleConfiguration() {
 	var configurationDiv = document.getElementById('configurationDiv');
-	configurationDiv.hidden = !configurationDiv.hidden; 
+	configurationDiv.hidden = !configurationDiv.hidden;
 
 	var contentDiv = document.getElementById('contentDiv');
-	contentDiv.hidden = !contentDiv.hidden; 
+	contentDiv.hidden = !contentDiv.hidden;
 }
 
 function updateApiDomain(apiDomain) {
@@ -117,7 +130,7 @@ function updateApiDomain(apiDomain) {
 
 function handleApiDomainUpdates() {
 	var apiDomainInput = document.getElementById('apiDomain');
-	
+
 	chrome.storage.local.get(['segment_api_domain'], function(result) {
 		apiDomainInput.value = result.segment_api_domain || apiDomainDefault;
 		apiDomainInput.onchange = () => updateApiDomain(apiDomainInput.value);
@@ -127,6 +140,10 @@ function handleApiDomainUpdates() {
 document.addEventListener('DOMContentLoaded', function() {
 	var clearButton = document.getElementById('clearButton');
 	clearButton.onclick = clearTabLog;
+
+	var filterInput = document.getElementById('filterInput');
+	filterInput.onkeyup = filterEvents;
+	filterInput.focus();
 
 	var configureButton = document.getElementById('configureButton');
 	configureButton.onclick = toggleConfiguration;


### PR DESCRIPTION
Hey thanks for this extension I find it useful on a daily basis. Would you consider this PR which adds the ability to filter events by their name? We have a bunch of events being fired (I mean who doesn't) and this helps find the ones we are looking for faster. Here are some screenshots of how it would look, I'm open to other styles too:

**Without filtering:**

![image](https://user-images.githubusercontent.com/17035407/115100585-f47d9d00-9f13-11eb-9494-403a86c1aab7.png)

**Filtering:**

![image](https://user-images.githubusercontent.com/17035407/115100527-9ea8f500-9f13-11eb-9de4-67cd66e4b303.png)
