### PR TITLE
Fix server events header casing

### DIFF
--- a/background.js
+++ b/background.js
@@ -145,13 +145,13 @@ chrome.webRequest.onBeforeRequest.addListener(
 chrome.webRequest.onHeadersReceived.addListener(
 	(details) => {
 		onOwnServerResponse(details.url, () => {
-			var eventsHeader = details.responseHeaders.find((header) => header.name === 'X-Tracked-Events');
+			const eventsHeader = details.responseHeaders.find(({ name }) => !!name && name.toLowerCase() === 'x-tracked-events');
 			if (!eventsHeader) return
 
 			withOpenTab((tab) => {
-				var serverTrackedEvents = JSON.parse(eventsHeader.value);
+				const serverTrackedEvents = JSON.parse(eventsHeader.value);
 				serverTrackedEvents.forEach((serverEvent) => {
-					var event = {
+					const event = {
 						type: serverEvent.type,
 						eventName: serverEvent.event || eventTypeToName(serverEvent.type),
 						raw: JSON.stringify(serverEvent),


### PR DESCRIPTION
There's an issue where if the header doesn't match the casing in the code then events will not be logged. This fixes it