### PR TITLE
Allow seeing events in real time

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,6 +36,11 @@ function withOpenTab(callback) {
 	});
 }
 
+function addEvent(event) {
+	trackedEvents.unshift(event);
+	chrome.runtime.sendMessage({ type: "new_event" });
+}
+
 function updateTrackedEventsForTab(tabId,port) {
 	var sendEvents = [];
 
@@ -129,7 +134,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 
 				if (event.type) {
 					event.eventName = eventTypeToName(event.type) || rawEvent.event
-					trackedEvents.unshift(event);
+					addEvent(event);
 				}
 			});
 		}
@@ -160,7 +165,7 @@ chrome.webRequest.onHeadersReceived.addListener(
 						tabId: tab.id
 					};
 
-					trackedEvents.unshift(event);
+					addEvent(event);
 				})
 			});
 		})

--- a/popup.js
+++ b/popup.js
@@ -59,6 +59,12 @@ var port = chrome.extension.connect({
 
 queryForUpdate();
 
+chrome.runtime.onMessage.addListener(function(message, _sender, _sendResponse){
+	if (message.type == 'new_event') {
+		queryForUpdate();
+	}
+});
+
 port.onMessage.addListener((msg) => {
 	if (msg.type == "update") {
 		// console.log(jsonObject);


### PR DESCRIPTION
This PR allows seeing events as they come in real-time, it's just a convenience to not have to close and open the chrome extension to reload them. It could be optimized to just add the new events and not re-create all the list but I tested it and it works well with ~200 events, which should be good enough for most use cases. 