### PR TITLE
Copy json option on the side of each event

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Segment Event Tracker",
   "manifest_version": 2,
-  "version": "2.2",
+  "version": "2.3",
   "description": "See when Segment and Dreamdata events are being tracked.",
   "permissions": [
   	"<all_urls>",

--- a/popup.css
+++ b/popup.css
@@ -81,6 +81,10 @@ body {
 	border-radius: 5px;
 }
 
+.copyEvent{
+	float: right;  
+}
+
 .string { color: green; }
 .number { color: blue; }
 .boolean { color: purple; }

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,6 @@
 var apiDomainDefault = 'api.segment.io,cdn.dreamdata.cloud';
+//Obtained from: https://uxwing.com/copy-icon/
+const copyJsonSVG = '<svg width="32" height="32" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 115.77 122.88" style="enable-background:new 0 0 115.77 122.88" xml:space="preserve"><style type="text/css">.st0{fill-rule:evenodd;clip-rule:evenodd;}</style><g><path class="st0" d="M89.62,13.96v7.73h12.19h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02v0.02 v73.27v0.01h-0.02c-0.01,3.84-1.57,7.33-4.1,9.86c-2.51,2.5-5.98,4.06-9.82,4.07v0.02h-0.02h-61.7H40.1v-0.02 c-3.84-0.01-7.34-1.57-9.86-4.1c-2.5-2.51-4.06-5.98-4.07-9.82h-0.02v-0.02V92.51H13.96h-0.01v-0.02c-3.84-0.01-7.34-1.57-9.86-4.1 c-2.5-2.51-4.06-5.98-4.07-9.82H0v-0.02V13.96v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07V0h0.02h61.7 h0.01v0.02c3.85,0.01,7.34,1.57,9.86,4.1c2.5,2.51,4.06,5.98,4.07,9.82h0.02V13.96L89.62,13.96z M79.04,21.69v-7.73v-0.02h0.02 c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v64.59v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h12.19V35.65 v-0.01h0.02c0.01-3.85,1.58-7.34,4.1-9.86c2.51-2.5,5.98-4.06,9.82-4.07v-0.02h0.02H79.04L79.04,21.69z M105.18,108.92V35.65v-0.02 h0.02c0-0.91-0.39-1.75-1.01-2.37c-0.61-0.61-1.46-1-2.37-1v0.02h-0.01h-61.7h-0.02v-0.02c-0.91,0-1.75,0.39-2.37,1.01 c-0.61,0.61-1,1.46-1,2.37h0.02v0.01v73.27v0.02h-0.02c0,0.91,0.39,1.75,1.01,2.37c0.61,0.61,1.46,1,2.37,1v-0.02h0.01h61.7h0.02 v0.02c0.91,0,1.75-0.39,2.37-1.01c0.61-0.61,1-1.46,1-2.37h-0.02V108.92L105.18,108.92z" stroke="gray" fill="white" fill-opacity="0.5"/></g></svg>'
 
 function showEvent(number) {
 	document.getElementById('eventContent_' + number).style.display = 'block';
@@ -79,9 +81,12 @@ port.onMessage.addListener((msg) => {
 				var eventString = '';
 
 				eventString += '<div class="eventTracked eventType_' + event.type + '">';
-					eventString += '<div class="eventInfo" number="' + i + '"><span class="eventName">' + event.eventName + '</span> - ' + event.trackedTime + '<br />' + event.hostName + '</div>';
-					eventString += '<div class="eventContent" id="eventContent_' + i + '">';
-						eventString += printVariable(jsonObject,0);
+					eventString += '<div class="eventInfo" id="eventInfo_'+i+'"><span class="eventName">' 
+						eventString += '<div class="copyEvent" id="copy_'+i+'"><a title="Copy json to clipboard">'+ copyJsonSVG + '</a></div>'
+							+ event.eventName + '</span> - ' + event.trackedTime + '<br />' + event.hostName 
+						eventString += '<div class="eventContent" id="eventContent_' + i + '" >';
+							eventString += printVariable(jsonObject,0);
+						eventString += '</div>';
 					eventString += '</div>';
 				eventString += '</div>';
 
@@ -93,10 +98,9 @@ port.onMessage.addListener((msg) => {
 		}
 		document.getElementById('trackMessages').innerHTML = prettyEventsString;
 
-		var eventElements = document.getElementsByClassName("eventInfo");
-		for (var i=0;i<eventElements.length;i++) {
-			eventElements[i].onclick = function() {
-				var number = this.getAttribute('number');
+		for (var i=0;i<msg.events.length;i++) {
+			const number = i;
+			document.getElementById('eventInfo_' + number).onclick = function() {
 				if (document.getElementById('eventContent_' + number).style.display == 'block') {
 					document.getElementById('eventContent_' + number).style.display = 'none';
 				}
@@ -104,7 +108,14 @@ port.onMessage.addListener((msg) => {
 					document.getElementById('eventContent_' + number).style.display = 'block';
 				}
 			};
+			document.getElementById('copy_'+number).onclick = function(event){
+				navigator.clipboard.writeText(msg.events[number].raw);
+				event.stopPropagation();
+			}
+			
 		}
+
+		
 	}
 });
 


### PR DESCRIPTION
Adding a small icon to the right of each event to copy the raw json into the clipboard.

I love the extension and use it daily, but many times i need the actual json, so i have to go to dev tools to copy it. This PR aims at removing that extra hustle.

