### PR TITLE
Support for Rudderstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # segment-chromeextension
 
-Chrome extension tracking [Segment](https://segment.com/) and [Dreamdata](https://dreamdata.io/) events, so you can easily see what's being sent.
+Chrome extension tracking [Segment](https://segment.com/), [Rudderstack](https://https://www.rudderstack.com/) and [Dreamdata](https://dreamdata.io/) events, so you can easily see what's being sent.
 
-Tracks all outgoing Segment and Dreamdata API calls, and shows them in the extension.
+Tracks all outgoing Segment, Rudderstack and Dreamdata API calls, and shows them in the extension.
 
 ## Screenshots
 ###### See what's tracked live

--- a/background.js
+++ b/background.js
@@ -119,18 +119,18 @@ chrome.webRequest.onBeforeRequest.addListener(
 				event.hostName = tab.url;
 				event.tabId = tab.id;
 
-				if (details.url.endsWith('/v1/t') || details.url.endsWith('/v2/t')) {
-					event.type = 'track';
-				}
-				else if (details.url.endsWith('/v1/i') || details.url.endsWith('/v2/i')) {
-					event.type = 'identify';
-				}
-				else if (details.url.endsWith('/v1/p') || details.url.endsWith('/v2/p')) {
-					event.type = 'pageLoad';
-				}
-				else if (details.url.endsWith('/v1/batch') || details.url.endsWith('/v2/batch') || details.url.endsWith('/v1/b') || details.url.endsWith('/v2/b')) {
-					event.type = 'batch';
-				}
+				if (details.url.endsWith('/v1/t') || details.url.endsWith('/v2/t') || details.url.endsWith('/v1/track')) {
+                    event.type = 'track';
+                }
+                else if (details.url.endsWith('/v1/i') || details.url.endsWith('/v2/i') || details.url.endsWith('/v1/identify')) {
+                    event.type = 'identify';
+                }
+                else if (details.url.endsWith('/v1/p') || details.url.endsWith('/v2/p') || details.url.endsWith('/v1/page')) {
+                    event.type = 'pageLoad';
+                }
+                else if (details.url.endsWith('/v1/batch') || details.url.endsWith('/v2/batch') || details.url.endsWith('/v1/b') || details.url.endsWith('/v2/b')) {
+                    event.type = 'batch';
+                }
 
 				if (event.type) {
 					event.eventName = eventTypeToName(event.type) || rawEvent.event

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Segment Event Tracker",
   "manifest_version": 2,
-  "version": "2.2",
-  "description": "See when Segment and Dreamdata events are being tracked.",
+  "version": "2.3",
+  "description": "See when Segment, Rudderstack and Dreamdata events are being tracked.",
   "permissions": [
   	"<all_urls>",
     "http://*/*",


### PR DESCRIPTION
This PR contains the tracking support for Rudderstack (https://www.rudderstack.com). 

The Rudderstack solution is comparable with dreamdata.

1 remark :  Due to the dynamic behavior of the dataplanes, no default API domain added

How to test it : configure emeraldx-dataplane.rudderstack.com, and navigate to :https://b2b.acorn.com/
