### PR TITLE
Add support for Firefox browser

### DIFF
--- a/background.js
+++ b/background.js
@@ -66,7 +66,7 @@ function clearTrackedEventsForTab(tabId,port) {
 	trackedEvents = newTrackedEvents;
 }
 
-chrome.extension.onConnect.addListener((port) => {
+chrome.runtime.onConnect.addListener((port) => {
 	port.onMessage.addListener((msg) => {
 		var tabId = msg.tabId;
 		if (msg.type == 'update') {

--- a/popup.js
+++ b/popup.js
@@ -55,7 +55,7 @@ function clearTabLog() {
 	});
 }
 
-var port = chrome.extension.connect({
+var port = chrome.runtime.connect({
 	name: "trackPopup"
 });
 


### PR DESCRIPTION
This PR aims to make the extension compatible with the Firefox browser by replacing the deprecated Message passing API.

By doing this, the extension works well in both Firefox and Chrome. Below is the result of running the extension in Firefox:
![screenshot](https://github.com/MartinMouritzen/segment-chromeextension/assets/31310280/63d7f3d8-6b27-42f8-b7d2-37daf85fe6f0)
